### PR TITLE
Auth

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,14 +2,14 @@ import logging
 import os
 import sys
 
+from dotenv import load_dotenv
 from flask import Flask
 from flask_restful import Api
-from dotenv import load_dotenv
 
 import config
 from auth import auth, jwt
-from routes import mongo, BasicInfo, Auth
 from models import sa
+from routes import mongo, BasicInfo, Auth
 
 app = Flask(__name__)
 # config

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from flask_restful import Api
 from dotenv import load_dotenv
 
 import config
-from auth import auth
+from auth import auth, jwt
 from routes import mongo, BasicInfo, Auth
 from models import sa
 
@@ -27,6 +27,9 @@ if ON_CLOUD:
 # logger
 app.logger.addHandler(logging.StreamHandler(sys.stdout))
 app.logger.setLevel(logging.ERROR)
+
+# JWT
+jwt.init_app(app)
 
 # mongo
 mongo.init_app(app)

--- a/auth.py
+++ b/auth.py
@@ -1,8 +1,29 @@
-from flask import Blueprint, jsonify, request
+from functools import wraps
 
-from models import User, sa
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import create_access_token, create_refresh_token, \
+    jwt_required, get_jwt_identity, JWTManager, verify_jwt_in_request, get_jwt
+
+from models import User, sa, RoleSchema
 
 auth = Blueprint('auth', __name__)
+jwt = JWTManager()
+
+
+def admin_required():
+    def wrapper(fn):
+        @wraps(fn)
+        def decorator(*args, **kwargs):
+            verify_jwt_in_request()
+            claims = get_jwt()
+            if claims["is_admin"]:
+                return fn(*args, **kwargs)
+            else:
+                return jsonify(msg="Admins only!"), 403
+
+        return decorator
+
+    return wrapper
 
 
 @auth.route('/register', methods=['POST'])
@@ -10,13 +31,15 @@ def register():
     data = request.get_json()
 
     try:
+        user = User.find(data['username'], data['email'])
+        if user:
+            return jsonify({'msg': f'User {user.username} already exists'}), 400
+
         user = User(
             username=data['username'],
             email=data['email']
         )
-        user.set_password(data['password'])
-        sa.session.add(user)
-        sa.session.commit()
+        User.create(user, data['password'])
         return jsonify({'msg': f'{user.username} is created'}), 201
     except AssertionError as e:
         return jsonify({'msg': f'{e}'}), 400
@@ -24,4 +47,41 @@ def register():
 
 @auth.route('/login', methods=['POST'])
 def login():
-    return jsonify({'method': 'login'})
+    data = request.get_json()
+    user = User.find(data['username'], data['email'])
+
+    if not user:
+        return jsonify({'msg': 'User not found'}), 404
+    elif not user.check_password(data['password']):
+        return jsonify({'msg': 'Password incorrect'}), 401
+
+    # roles = RoleSchema().dump(user.roles)
+    access_token = create_access_token(
+        identity=user.id,
+        additional_claims={
+            'is_admin': False
+            # 'is_admin': any(x.name.upper() == "ADMIN" for x in roles)
+        })
+    refresh_token = create_refresh_token(identity=user.id)
+    return jsonify(access_token=access_token, refresh_token=refresh_token)
+
+
+@auth.route('/refresh', methods=['POST'])
+@jwt_required(refresh=True)
+def refresh():
+    identity = get_jwt_identity()
+    access_token = create_access_token(identity=identity)
+    return jsonify(access_token=access_token)
+
+
+@auth.route("/identity", methods=["GET"])
+@jwt_required()
+def protected():
+    identity = get_jwt_identity()
+    return jsonify(identity=identity)
+
+
+@auth.route('/admin', methods=['GET'])
+@admin_required()
+def test_admin():
+    return jsonify(msg='Admin authorized')

--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import timedelta
 
 from dotenv import load_dotenv
 
@@ -20,3 +21,7 @@ class Config:
                               f"{os.getenv('MYSQL_HOST')}/" \
                               f"{os.getenv('MYSQL_DB')}"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY')
+    JWT_ACCESS_TOKEN_EXPIRES = timedelta(hours=1)
+    JWT_REFRESH_TOKEN_EXPIRES = timedelta(days=30)

--- a/models.py
+++ b/models.py
@@ -2,24 +2,29 @@ import re
 import uuid
 
 from email_validator import validate_email, EmailNotValidError
+from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
-from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
+from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field, fields
 from sqlalchemy import or_, Table, Column, String, Integer, ForeignKey, DateTime, func
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import validates, relationship
 from werkzeug.security import generate_password_hash, check_password_hash
 
 sa = SQLAlchemy()
+Base = declarative_base()
+Base.query = sa.session.query_property()
 
-user_roles = Table('user_roles', sa.metadata,
+user_roles = Table('user_roles', Base.metadata,
                    Column('user_id', String(50), ForeignKey('user.id')),
                    Column('role_id', Integer, ForeignKey('role.id')))
 
 
-class User(sa.Model):
+class User(Base, UserMixin):
     __tablename__ = 'user'
-    id = Column(String, primary_key=True)
-    email = Column(String(50), index=True, unique=True, nullable=False)
-    username = Column(String(50), index=True, unique=True, nullable=False)
+
+    id = Column(String(50), primary_key=True)
+    email = Column(String(255), index=True, unique=True, nullable=False)
+    username = Column(String(20), index=True, unique=True, nullable=False)
     password_hash = Column(String(255), nullable=False)
     created_at = Column(DateTime, server_default=func.now())
     updated_at = Column(DateTime, server_default=func.now(), server_onupdate=func.now())
@@ -85,8 +90,9 @@ class User(sa.Model):
             raise AssertionError(str(e))
 
 
-class Role(sa.Model):
-    __tablename__ = 'roles'
+class Role(Base):
+    __tablename__ = 'role'
+
     id = Column(Integer, primary_key=True)
     name = Column(String(25), nullable=False)
 
@@ -97,7 +103,7 @@ class UserSchema(SQLAlchemySchema):
 
     id = auto_field()
     username = auto_field()
-    # roles = fields.Nested('RoleSchema', many=True, exclude=('user',))
+    roles = fields.Nested('RoleSchema', many=True, exclude=('users',))
 
 
 class RoleSchema(SQLAlchemySchema):
@@ -106,4 +112,4 @@ class RoleSchema(SQLAlchemySchema):
 
     id = auto_field()
     name = auto_field()
-    # users = fields.Nested('UserSchema', many=True, exclude=('role',))
+    users = fields.Nested('UserSchema', many=True, exclude=('roles',))

--- a/routes.py
+++ b/routes.py
@@ -1,6 +1,8 @@
 from flask import jsonify
 from flask_pymongo import PyMongo
 from flask_restful import Resource, reqparse
+
+from auth import admin_required
 from models import User, UserSchema
 
 parser = reqparse.RequestParser()
@@ -25,6 +27,10 @@ class BasicInfo(Resource):
             b.pop('_id')
             return jsonify(b)
         return {'msg': 'The requested object does not exist.'}, 404
+
+    @admin_required()
+    def post(self):
+        pass
 
 
 class Auth(Resource):


### PR DESCRIPTION
**Description**:

1. JWT with Role-based Authentication requires many-to-many relationship between User and Role.
Previously, it kept giving NoForeignKey error.
2. Either flask-user or flask-jwt-extend should be implemented for role-based authentication

Cause:

1. User and Role were implemented with ```SQLAlchemy```, which was not detecting the ForeignKeys.

Solution:

1. After replacing ```SQLAlchemy``` with ```declarative_base ```, the ForeignKeys are detected successfully.
2. ```flask-user``` is easier to use, but it requires additional email configurations that is not currently available.